### PR TITLE
Add selected documentation; fix warnings; bug fix

### DIFF
--- a/subprojects/client-javascript/dolphin-client-javascript.gradle
+++ b/subprojects/client-javascript/dolphin-client-javascript.gradle
@@ -83,7 +83,7 @@ task install (dependsOn: [compileTypeScript, jsZip, updateGrailsJs])
 
 // ------------- Create webjar for OpenDolphinJS: --------------------
 jar {
-    dependsOn compileTypeScript
+    // dependsOn compileTypeScript // disabled until typescript is installed on Teamcity server
     from(fileTree(dir: "${projectDir}/build", includes: ['*.js', '*.js.map'])) {
         into "META-INF/resources/webjars/org/opendolphin/${version}"
     }

--- a/subprojects/client-javascript/dolphin-client-javascript.gradle
+++ b/subprojects/client-javascript/dolphin-client-javascript.gradle
@@ -83,7 +83,7 @@ task install (dependsOn: [compileTypeScript, jsZip, updateGrailsJs])
 
 // ------------- Create webjar for OpenDolphinJS: --------------------
 jar {
-    // dependsOn compileTypeScript // disabled until typescript is installed on Teamcity server
+    dependsOn compileTypeScript
     from(fileTree(dir: "${projectDir}/build", includes: ['*.js', '*.js.map'])) {
         into "META-INF/resources/webjars/org/opendolphin/${version}"
     }

--- a/subprojects/client-javascript/dolphin-client-javascript.gradle
+++ b/subprojects/client-javascript/dolphin-client-javascript.gradle
@@ -6,7 +6,18 @@
 // You can also run the tasks compileTypeScript, jsZip, and updateGrailsJs in isolation.
 
 // This build file requires a nodejs and tsc installation.
-
+//
+// To produce a webjar containing opendolphin.js:
+// Call:
+//   ../../gradlew jar
+// which will result in: build/libs/opendolphinjs-${version}.jar,
+// which can be installed to the local maven repository (~/.m2) by calling
+//   ../../gradlew -i publishToMavenLocal
+// To be able to upload it to bintray you need to be a member of the bintray-opendolphin organisation.
+// Then invoke:
+//   ../../gradlew -i bintrayUpload
+// and confirm the publishing notification on the bintray website.
+//
 
 buildscript {
     repositories {
@@ -17,11 +28,21 @@ buildscript {
 		}
     }
     dependencies {
-		classpath 'de.richsource.gradle.plugins:typescript-gradle-plugin:1.0.5'
+		classpath 'de.richsource.gradle.plugins:typescript-gradle-plugin:1.0.6'
     }
 }
-// Invoke the plugin
+
+plugins {
+    id "com.jfrog.bintray" version "1.0"
+}
+
 apply plugin: 'typescript'
+
+// used to produce webjar:
+apply plugin: 'java'
+apply plugin: 'maven-publish'
+
+version = '0.12.0B2' // overwrite version here until we get a stable release
 
 task updateGrailsJs << {
     ant.delete dir: '../../dolphin-grails/web-app/js/dolphin'
@@ -59,3 +80,36 @@ compileTypeScript {
 }
 
 task install (dependsOn: [compileTypeScript, jsZip, updateGrailsJs])
+
+// ------------- Create webjar for OpenDolphinJS: --------------------
+jar {
+    dependsOn compileTypeScript
+    from(fileTree(dir: "${projectDir}/build", includes: ['*.js', '*.js.map'])) {
+        into "META-INF/resources/webjars/org/opendolphin/${version}"
+    }
+    baseName = 'opendolphinjs'
+    outputs.file archivePath
+}
+publishing {
+    publications {
+        mavenJavascript(MavenPublication) {
+            artifact jar {
+            }
+        }
+    }
+}
+
+bintray {
+    dryRun = false
+    user = bintrayUser
+    key = bintrayKey
+    publications = ['mavenJavascript']
+    pkg {
+        userOrg = 'opendolphin'
+        repo = 'mavenrepo'
+        name = 'open-dolphin-client-javascript'
+        licenses = ['Apache-2.0']
+    }
+}
+// ---------------------------------
+

--- a/subprojects/client-javascript/dolphin-client-javascript.gradle
+++ b/subprojects/client-javascript/dolphin-client-javascript.gradle
@@ -99,10 +99,12 @@ publishing {
     }
 }
 
+// Please configure your personal bintray credentials via 'bintrayUser' and 'bintrayKey' in '~/.gradle/gradle.properties' to
+// be able execute the following task:
 bintray {
     dryRun = false
-    user = bintrayUser
-    key = bintrayKey
+    user = project.hasProperty('bintrayUser') ? bintrayUser : '-'
+    key = project.hasProperty('bintrayKey') ? bintrayKey : '-'
     publications = ['mavenJavascript']
     pkg {
         userOrg = 'opendolphin'

--- a/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
+++ b/subprojects/shared/src/test/groovy/org/opendolphin/core/comm/JsonCodecTest.groovy
@@ -88,7 +88,7 @@ public class JsonCodecTest extends GroovyTestCase {
         assertCodingCommand(new CreatePresentationModelCommand())
         assertCodingCommand(new ChangeAttributeMetadataCommand())
         assertCodingCommand(new GetPresentationModelCommand())
-        assertCodingCommand(new DataCommand([a:1, b:2]))
+        assertCodingCommand(new DataCommand([a:1, b:2.5d]))
         assertCodingCommand(new DeleteAllPresentationModelsOfTypeCommand())
         assertCodingCommand(new DeletedAllPresentationModelsOfTypeNotification())
         assertCodingCommand(new DeletedPresentationModelNotification())


### PR DESCRIPTION
- Eliminate bindInfo warnings (use new syntax "bindInfo ..of..using..to") in demo clients.
- Document PresentationModel, Attribute, and Tag interfaces. 
- Document AttributeTagView demo client. 
- Change GroovyFX dependency for demo-javafx/client from 0.2 to 0.4.0 so that demos will run under Java 8. 
- Eliminate warnings; fix usage of deprecated "dolphin.changeValue" method (use changeValueCommand instead.) 
- Fix potential bug in BasePresentationModel.findAttributeById where Java strings were compared for identity, not equality.
